### PR TITLE
Fixed incorrect error-throwing issue when no city was found

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -92,6 +92,9 @@ function findNearestZOrder (k, lat, lon) {
   });
 
   var pos = Math.abs(bsearch(objs, geohash.encode(lat, lon, 6)));
+  if (!objs[pos]) {
+    return [];
+  }
   var count = objs[pos].l.length;
   var maxOffset = Math.min(pos, (objs.length - pos));
   var offset = 4;


### PR DESCRIPTION
Now just empty result array is returned when nothing is found.
